### PR TITLE
Add support for running tasks with fuse being enabled in PAPI

### DIFF
--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -251,6 +251,28 @@ standards for memory for a VM. So it's possible that even though the request say
 Two environment variables called `${MEM_UNIT}` and `${MEM_SIZE}` are also available inside the command block of a task,
 making it easy to retrieve the new value of memory on the machine.
 
+**Enabling fuse capabilities**
+
+By default cromwell task containers doesn't allow to mount any fuses. It happens because containers are launched without specific linux capabilities being enabled. 
+Google pipelines backend supports running containers with the enabled capabilities and so does cromwell. 
+
+If you need to use fuses within task containers then you can set `enable_fuse` workflow option. 
+
+```
+{
+    "enable_fuse": true
+}
+```
+
+Differently you can enable support for fuses right in your backend configuration.
+
+```
+backend.providers.Papiv2.config {
+    genomics {
+        enable-fuse = true
+    }
+}
+```
 
 #### Google Labels
 

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -12,6 +12,7 @@ Keys | Possible Values | Description
 `monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
 `monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
 `google_labels` | `object` | An object containing only string values. Represent custom labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `[a-z]([-a-z0-9]*[a-z0-9])?`.
+`enable_fuse` | `boolean` | Specifies if workflow tasks should be submitted to Google Pipelines with an additional `ENABLE_FUSE` flag. It causes container to be executed with `CAP_SYS_ADMIN`. Use it only for trusted containers.
 
 # Example
 ```json
@@ -19,12 +20,13 @@ Keys | Possible Values | Description
   "jes_gcs_root": "gs://my-bucket/workflows",
   "google_project": "my_google_project",
   "refresh_token": "1/Fjf8gfJr5fdfNf9dk26fdn23FDm4x",
-  "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com"
+  "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com",
   "auth_bucket": "gs://my-auth-bucket/private",
   "monitoring_script": "gs://bucket/script.sh",
   "monitoring_image": "quay.io/broadinstitute/cromwell-monitor",
   "google_labels": {
     "custom-label": "custom-value"
-  }
+  },
+  "enable_fuse": true
 }
 ```

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -391,6 +391,10 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     descriptor.workflowOptions.getOrElse(WorkflowOptionKeys.GoogleComputeServiceAccount, jesAttributes.computeServiceAccount)
   }
 
+  protected def fuseEnabled(descriptor: BackendWorkflowDescriptor): Boolean = {
+    descriptor.workflowOptions.getBoolean(WorkflowOptionKeys.EnableFuse).toOption.getOrElse(jesAttributes.enableFuse)
+  }
+
   override def isTerminal(runStatus: RunStatus): Boolean = {
     runStatus match {
       case _: TerminalRunStatus => true
@@ -445,6 +449,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           adjustedSizeDisks = adjustedSizeDisks,
           virtualPrivateCloudConfiguration = jesAttributes.virtualPrivateCloudConfiguration,
           retryWithMoreMemoryKeys = jesAttributes.memoryRetryConfiguration.map(_.errorKeys),
+          fuseEnabled = fuseEnabled(jobDescriptor.workflowDescriptor),
         )
       case Some(other) =>
         throw new RuntimeException(s"Unexpected initialization data: $other")

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -29,6 +29,7 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                computeServiceAccount: String,
                                                auths: PipelinesApiAuths,
                                                restrictMetadataAccess: Boolean,
+                                               enableFuse: Boolean,
                                                executionBucket: String,
                                                endpointUrl: URL,
                                                maxPollingInterval: Int,
@@ -68,6 +69,7 @@ object PipelinesApiConfigurationAttributes {
     "genomics.compute-service-account",
     "genomics.auth",
     "genomics.restrict-metadata-access",
+    "genomics.enable-fuse",
     "genomics.endpoint-url",
     "genomics-api-queries-per-100-seconds",
     "genomics.localization-attempts",
@@ -148,6 +150,7 @@ object PipelinesApiConfigurationAttributes {
     val computeServiceAccount: String = backendConfig.as[Option[String]]("genomics.compute-service-account").getOrElse("default")
     val genomicsAuthName: ErrorOr[String] = validate { backendConfig.as[String]("genomics.auth") }
     val genomicsRestrictMetadataAccess: ErrorOr[Boolean] = validate { backendConfig.as[Option[Boolean]]("genomics.restrict-metadata-access").getOrElse(false) }
+    val genomicsEnableFuse: ErrorOr[Boolean] = validate { backendConfig.as[Option[Boolean]]("genomics.enable-fuse").getOrElse(false) }
     val gcsFilesystemAuthName: ErrorOr[String] = validate { backendConfig.as[String]("filesystems.gcs.auth") }
     val qpsValidation = validateQps(backendConfig)
     val duplicationStrategy = validate { backendConfig.as[Option[String]]("filesystems.gcs.caching.duplication-strategy").getOrElse("copy") match {
@@ -204,6 +207,7 @@ object PipelinesApiConfigurationAttributes {
                                                        endpointUrl: URL,
                                                        genomicsName: String,
                                                        restrictMetadata: Boolean,
+                                                       enableFuse: Boolean,
                                                        gcsName: String,
                                                        qps: Int Refined Positive,
                                                        cacheHitDuplicationStrategy: PipelinesCacheHitDuplicationStrategy,
@@ -219,6 +223,7 @@ object PipelinesApiConfigurationAttributes {
             computeServiceAccount = computeServiceAccount,
             auths = PipelinesApiAuths(genomicsAuth, gcsAuth),
             restrictMetadataAccess = restrictMetadata,
+            enableFuse = enableFuse,
             executionBucket = bucket,
             endpointUrl = endpointUrl,
             maxPollingInterval = maxPollingInterval,
@@ -238,6 +243,7 @@ object PipelinesApiConfigurationAttributes {
       endpointUrl,
       genomicsAuthName,
       genomicsRestrictMetadataAccess,
+      genomicsEnableFuse,
       gcsFilesystemAuthName,
       qpsValidation,
       duplicationStrategy,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
@@ -5,4 +5,5 @@ object WorkflowOptionKeys {
   val MonitoringImage = "monitoring_image"
   val GoogleProject = "google_project"
   val GoogleComputeServiceAccount = "google_compute_service_account"
+  val EnableFuse = "enable_fuse"
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -78,7 +78,8 @@ object PipelinesApiRequestFactory {
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],
                                       adjustedSizeDisks: Seq[PipelinesApiAttachedDisk],
                                       virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration],
-                                      retryWithMoreMemoryKeys: Option[List[String]]) {
+                                      retryWithMoreMemoryKeys: Option[List[String]],
+                                      fuseEnabled: Boolean) {
     def literalInputs = inputOutputParameters.literalInputParameters
     def inputParameters = inputOutputParameters.fileInputParameters
     def outputParameters = inputOutputParameters.fileOutputParameters

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -99,7 +99,8 @@ object ActionBuilder {
                  scriptContainerPath: String,
                  mounts: List[Mount],
                  jobShell: String,
-                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken]): Action = {
+                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
+                 fuseEnabled: Boolean): Action = {
 
     val dockerImageIdentifier = DockerImageIdentifier.fromString(docker)
 
@@ -117,7 +118,7 @@ object ActionBuilder {
       .setEntrypoint("")
       .setLabels(Map(Key.Tag -> Value.UserAction).asJava)
       .setCredentials(secret.orNull)
-      .setFlags(List(ActionFlag.EnableFuse.toString).asJava)
+      .setFlags((if (fuseEnabled) List(ActionFlag.EnableFuse.toString) else List.empty).asJava)
   }
 
   def checkForMemoryRetryAction(retryLookupKeys: List[String], mounts: List[Mount]): Action = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -117,6 +117,7 @@ object ActionBuilder {
       .setEntrypoint("")
       .setLabels(Map(Key.Tag -> Value.UserAction).asJava)
       .setCredentials(secret.orNull)
+      .setFlags(List(ActionFlag.EnableFuse.toString).asJava)
   }
 
   def checkForMemoryRetryAction(retryLookupKeys: List[String], mounts: List[Mount]): Action = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
@@ -10,7 +10,8 @@ trait UserAction {
       createPipelineParameters.commandScriptContainerPath.pathAsString,
       mounts,
       createPipelineParameters.jobShell,
-      createPipelineParameters.privateDockerKeyAndEncryptedToken
+      createPipelineParameters.privateDockerKeyAndEncryptedToken,
+      createPipelineParameters.fuseEnabled
     )
 
     val describeAction = ActionBuilder.describeDocker("user action", userAction)


### PR DESCRIPTION
By default all cromwell task containers submitted by Google Cloud backend doesn't allow user to mount any filesystems within a container. It happens because containers are launched without specific linux capabilities being enabled. 

Nevertheless filesystem mounts can be of help in some workflows because it doesn't require all the task resources to be localized or to be embedded in docker images.

Google pipelines api allows to set `ENABLE_FUSE` flag for all submitted action. Once specified it forces Google pipelines engine to launch action containers with additional linux capabilities such as `CAP_SYS_ADMIN` being enabled.

The pull request adds support for launching cromwell task containers with an enabled support for fuses in Google Cloud.

Fuses support can be enabled via a workflow option `enable_fuse` or via a Google Cloud backend configuration attribute `backend.providers.Papiv2.config.genomics.enable-fuse`.