### PR TITLE
Add support for `machineType` runtime parameter and latest CPU for custom instances

### DIFF
--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -202,6 +202,33 @@ If the Docker image to be pulled is not public the `docker pull` will fail which
 If using any of these private Docker workflow options it is advisable to add
 them to the `workflow-options.encrypted-fields` list in Cromwell configuration.
 
+**Runtime Compute Engine configuration**  
+_runtime_ section of the WDL task contains information about the required computational resources.
+```
+runtime {
+    cpu: CPU_COUNT
+    memory: MEM_SIZE
+    cpuPlatform: PLATFORM
+  }
+```
+By default Cromwell creates custom type instances:  
+>{PREFIX}custom-X-Y
+where
+* PREFIX indicates generation: "n2-" for Cascade Lake CPUs, empty for others
+* X - vCPUs count
+* Y - memory size (MB)  
+
+You can use predefined [machine type](https://cloud.google.com/compute/docs/machine-types) instances using `machineType` tag.
+```
+runtime {
+    machineType: M_TYPE
+  }
+```
+Be aware, when you define both `machineType` and `cpuPlatform`, because instance type [must be available](https://cloud.google.com/compute/docs/cpu-platforms) 
+for CPU platform, or you will receive 
+> The selected machine type (_type_name_) is not compatible with CPU platform _platform_
+
+exception failing your workflow.  
 
 **Monitoring**
 

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -206,29 +206,22 @@ them to the `workflow-options.encrypted-fields` list in Cromwell configuration.
 _runtime_ section of the WDL task contains information about the required computational resources.
 ```
 runtime {
-    cpu: CPU_COUNT
-    memory: MEM_SIZE
-    cpuPlatform: PLATFORM
-  }
+    cpu: 2
+    memory: '4 GB'
+    cpuPlatform: 'Intel Skylake'
+}
 ```
-By default Cromwell creates custom type instances:  
->{PREFIX}custom-X-Y
-where
-* PREFIX indicates generation: "n2-" for Cascade Lake CPUs, empty for others
-* X - vCPUs count
-* Y - memory size (MB)  
-
-You can use predefined [machine type](https://cloud.google.com/compute/docs/machine-types) instances using `machineType` tag.
+You can use predefined [machine type](https://cloud.google.com/compute/docs/machine-types) instances with `machineType` attribute.
 ```
 runtime {
-    machineType: M_TYPE
-  }
+    machineType: 'n2-standard-8'
+}
 ```
-Be aware, when you define both `machineType` and `cpuPlatform`, because instance type [must be available](https://cloud.google.com/compute/docs/cpu-platforms) 
-for CPU platform, or you will receive 
-> The selected machine type (_type_name_) is not compatible with CPU platform _platform_
+Cromwell supports all currently available CPU platforms for custom and predefined configurations.
 
-exception failing your workflow.  
+Be aware, when you define both `machineType` and `cpuPlatform`, because instance type [must be available](https://cloud.google.com/compute/docs/cpu-platforms) 
+for CPU platform, or you will receive an exception failing your workflow.
+> The selected machine type (_type_name_) is not compatible with CPU platform _platform_
 
 **Monitoring**
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineSpecifications.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineSpecifications.scala
@@ -1,0 +1,36 @@
+package cromwell.backend.google.pipelines.v2alpha1
+
+import wdl4s.parser.MemoryUnit
+import wom.format.MemorySize
+
+object MachineSpecifications {
+  // https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type
+  // https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#specifications
+  trait MachineSpecification {
+    def getSupportedPlatforms:List[String] = List.empty
+    def getMinMemoryPerCpu: MemorySize
+    def getMaxMemoryPerCpu: MemorySize
+    def getPrefix: String
+  }
+
+  private object N1MachineSpecification extends MachineSpecification {
+    override def getMinMemoryPerCpu: MemorySize = MemorySize(0.9, MemoryUnit.GB)
+    override def getMaxMemoryPerCpu: MemorySize = MemorySize(6.5, MemoryUnit.GB)
+    override def getPrefix: String = ""
+  }
+
+  private object N2machineSpecification extends MachineSpecification {
+    override def getSupportedPlatforms:List[String] = List("Intel Cascade Lake")
+    override def getMinMemoryPerCpu: MemorySize = MemorySize(0.5, MemoryUnit.GB)
+    override def getMaxMemoryPerCpu: MemorySize = MemorySize(8, MemoryUnit.GB)
+    override def getPrefix: String = "n2-"
+  }
+
+  def getMachineTypeSpecifications(cpuPlatform: Option[String]): MachineSpecification = {
+    if (cpuPlatform.isDefined
+        && N2machineSpecification.getSupportedPlatforms.contains(cpuPlatform.get))
+      N2machineSpecification
+    else
+      N1MachineSpecification
+  }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesUtilityConversions.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesUtilityConversions.scala
@@ -15,7 +15,8 @@ import scala.util.Try
 
 trait PipelinesUtilityConversions {
   def toAccelerator(gpuResource: GpuResource) = new Accelerator().setCount(gpuResource.gpuCount.value.toLong).setType(gpuResource.gpuType.toString)
-  def toMachineType(jobLogger: JobLogger)(attributes: PipelinesApiRuntimeAttributes) = MachineConstraints.machineType(attributes.memory, attributes.cpu, jobLogger)
+  def toMachineType(jobLogger: JobLogger)(attributes: PipelinesApiRuntimeAttributes) =
+    attributes.machineType.getOrElse(MachineConstraints.machineType(attributes.memory, attributes.cpu, attributes.cpuPlatform, jobLogger))
   def toMounts(parameters: CreatePipelineParameters): List[Mount] = parameters.adjustedSizeDisks.map(toMount).toList
   def toDisks(parameters: CreatePipelineParameters): List[Disk] = parameters.adjustedSizeDisks.map(toDisk).toList
   def toMount(disk: PipelinesApiAttachedDisk) = new Mount()


### PR DESCRIPTION
Cromwell engine used to build only custom-type Compute Engine instances for workflow execution.
* Right now the user is able to specify predefined [`machineType`](https://cloud.google.com/compute/docs/machine-types) in runtime section of the task. When you specify both `machineType` and `cpuPlatform` ensure its combination is [supported](https://cloud.google.com/compute/docs/cpu-platforms).
* Minor change to custom instance definition: previously Cascade Lake CPUs were not supported, because the format for n2-custom machines differs from n1. Currently, Cromwell is analyzing, if `cpuPlatform` refers to n2 generation, and use the correct format.